### PR TITLE
Declare as module

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,6 @@
 		"tslint-config-prettier": "^1.18.0",
 		"typescript": "^3.3.3333"
 	},
-	"license": "ISC"
+	"license": "ISC",
+	"type": "module"
 }


### PR DESCRIPTION
Declare this package as a module, which fixes error "Unexpected token export" when importing this with Vite.